### PR TITLE
Handle unknown nested inline elements

### DIFF
--- a/test/xml-js/xmlToObject.test.js
+++ b/test/xml-js/xmlToObject.test.js
@@ -27,7 +27,12 @@ describe('extractValue() converts XML source/target values into xliff.js objects
     });
   });
 
-  it('returns an empty string for an unknown inline element type (or other object', () => {
+  it('creates objects unknown inline element types if it contains elements', () => {
+    const elements = [{ type: 'text', text: 'Hello' }];
+    expect(extractValue({ type: 'element', name: 'foo', attributes: { id: '1' }, elements }, ElementTypes12)).to.eql('Hello');
+  });
+
+  it('returns an empty string for an unknown inline element type without elements (or other object', () => {
     expect(extractValue({ type: 'element', name: 'foo', attributes: { id: '1' } }, ElementTypes12)).to.eql('');
   });
 

--- a/xml-js/xmlToObject.js
+++ b/xml-js/xmlToObject.js
@@ -18,16 +18,22 @@ function extractValue(valueElements, elementTypeInfo) {
 
   // nested inline element tag
   const elementType = tagToElementType(valueElement.name, elementTypeInfo);
-  if (valueElement.type === 'element' && elementType !== undefined) {
-    const inlineElementFactory = elementTypeInfo.factories[elementType];
-    return inlineElementFactory(
-      valueElement.name,
-      valueElement.attributes.id,
-      valueElement.attributes,
-      extractValue(valueElement.elements, elementTypeInfo)
-    );
-  }
 
+  if (valueElement.type === 'element') {
+    if (elementType !== undefined) {
+      const inlineElementFactory = elementTypeInfo.factories[elementType];
+      return inlineElementFactory(
+        valueElement.name,
+        valueElement.attributes.id,
+        valueElement.attributes,
+        extractValue(valueElement.elements, elementTypeInfo)
+      );
+    } else {
+      return valueElement.elements
+        ? extractValue(valueElement.elements, elementTypeInfo)
+        : '';
+    }
+  }
   // just ignore anything else
   return '';
 }


### PR DESCRIPTION
![](https://media.giphy.com/media/2tQq8DVu0ARxGaXMhL/giphy.gif)

Some tools like SDL Trados add extra tags like `<mrk>` inside of the `<target>` tag.  Currently, if there was an unknown element tag it would just return ''.  This allows it to still process any nested tags inside of it as normal and ignore the unknown tag.